### PR TITLE
Fix contradictory Docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,20 @@ curl --unix-socket ./modelplex.socket \
 ## Docker
 
 ```bash
-# Build and run
+# Build the image
 docker build -t modelplex .
-docker run -v /path/to/config.toml:/config.toml \
-           -v /path/to/socket:/socket \
-           modelplex --config /config.toml --socket /socket/modelplex.socket
+
+# Run with custom config and socket directory
+docker run -v /path/to/your/config.toml:/app/config.toml \
+           -v /path/to/socket/dir:/tmp/modelplex \
+           modelplex
+
+# Or run with default config and expose socket to host
+docker run -v /host/socket/dir:/tmp/modelplex \
+           modelplex
 ```
+
+The socket will be available at `/host/socket/dir/modelplex.socket` on your host system.
 
 ## License
 


### PR DESCRIPTION
## Problem
The Docker instructions in the README were confusing and contradictory:
- Mixed volume mount paths (`/socket` vs `/socket/modelplex.socket`)
- Didn't align with the Dockerfile's actual volume configuration
- Unclear where the socket file would actually be located

## Solution
- Aligned Docker instructions with Dockerfile's `/tmp/modelplex` volume
- Provided clear examples for both custom and default config usage
- Explained where socket file will be located on host system
- Removed contradictory path references

## Changes
- Fixed volume mount paths to use `/tmp/modelplex` consistently
- Updated config file path to match Dockerfile's `/app/config.toml`
- Added clear explanation of socket file location
- Provided two usage examples: custom config and default config

Fixes the confusing Docker setup instructions mentioned in the issue.