### PR TITLE
fix: resolve CI Docker build failure and add conditional Docker testing [test-docker]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.24.4'
 
     - name: Run tests
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,9 @@ jobs:
         images: ghcr.io/${{ github.repository }}
         tags: |
           type=ref,event=branch
-          type=sha,prefix={{branch}}-,format=short,length=10
+          type=ref,event=pr,prefix=pr-
+          type=sha,prefix={{branch}}-,format=short,length=10,enable={{is_default_branch}}
+          type=sha,prefix=pr-,format=short,length=10,enable=${{ github.event_name == 'pull_request' }}
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build Docker image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: [test, lint]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.title, '[test-docker]')
     permissions:
       contents: read
       packages: write
@@ -167,6 +167,7 @@ jobs:
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
+      if: github.ref == 'refs/heads/main'
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -195,13 +196,21 @@ jobs:
 
     - name: Test Docker image
       run: |
-        # Test the built image before pushing (using short SHA)
-        SHORT_SHA=$(git rev-parse --short=10 ${{ github.sha }})
-        docker run --rm ghcr.io/${{ github.repository }}:main-${SHORT_SHA} --version
-        docker run --rm ghcr.io/${{ github.repository }}:main-${SHORT_SHA} --help
+        # Test the built image (using appropriate tag based on context)
+        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          SHORT_SHA=$(git rev-parse --short=10 ${{ github.sha }})
+          IMAGE_TAG="ghcr.io/${{ github.repository }}:main-${SHORT_SHA}"
+        else
+          # For PR builds, use the first tag from metadata
+          IMAGE_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+        fi
+        echo "Testing Docker image: $IMAGE_TAG"
+        docker run --rm $IMAGE_TAG --version
+        docker run --rm $IMAGE_TAG --help
 
     - name: Push Docker image
       uses: docker/build-push-action@v6
+      if: github.ref == 'refs/heads/main'
       with:
         context: .
         push: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/modelplex/modelplex
 
-go 1.24
+go 1.24.4
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
## Summary
- Fix GitHub Actions Docker build failure by updating go.mod to use Go 1.24.4 to match Dockerfile version
- Add conditional Docker testing feature that triggers on `[test-docker]` magic flag in PR titles, allowing developers to test Docker builds in PRs without pushing to registry

## Test plan
- [x] Verify Go version consistency across go.mod, Dockerfile, and CI workflows
- [x] Test local build with `go build ./cmd/modelplex`
- [ ] Verify CI Docker job runs due to `[test-docker]` flag in this PR title
- [ ] Confirm Docker image builds and tests successfully
- [ ] Ensure no registry push occurs (PR context, not main branch)

🤖 Generated with [Claude Code](https://claude.ai/code)